### PR TITLE
Automatically run linters

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,0 +1,24 @@
+---
+
+name: Ansible lint
+
+on:  # yamllint disable-line rule:truthy
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install dependencies
+        run: >
+          pip3 install
+          ansible-lint
+          yamllint
+
+      - run: ansible-lint
+
+      - run: yamllint --strict .

--- a/.yamllint
+++ b/.yamllint
@@ -4,8 +4,17 @@ extends: default
 
 rules:
   line-length: disable
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false
+  braces:
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
 
 ignore: |
   venv/
   .roles/
   .cache/
+  templates/opensearch.yml

--- a/tasks/opensearch.yml
+++ b/tasks/opensearch.yml
@@ -16,7 +16,7 @@
     marker: "## {mark} opensearch main configuration ##"
     owner: "opensearch"
     group: "opensearch"
-    mode: 0600
+    mode: "0600"
 
 - name: OpenSearch Install | Adjust heap size
   notify: Restart opensearch


### PR DESCRIPTION
This patch adds a GitHub Action workflow to automatically run ansible-line and yamllint on all pull requests and pushes.

It also updates the yamllint configuration ansible-lint was complaining about and fixes one complaint in the code.