### PR TITLE
(Re-)start service with notify

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This role supports the following,
   - Defaults to `127.0.0.1`.
 - `opensearch_api_port`
   - Defaults to `9200`.
+- `opencast_opensearch_started`
+  - By default, the OpenSearch service will (re)start if something has changed that requires the service to be restarted. This is done via the Ansible notification handler. However, if you expect the OpenSearch service to be running when you run this role, you can force the service to start by setting the value to `true`.
+  - Defaults to `false` (make use of Ansible Handler to reach the state)
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,6 @@ opensearch_api_host: 127.0.0.1
 
 # Bind OpenSearch to this specific port.
 opensearch_api_port: 9200
+
+# Whether to force the start of the OpenSearch service at the end of this role.
+opencast_opensearch_started: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,8 +2,7 @@
 - name: Include opensearch installation
   ansible.builtin.import_tasks: opensearch.yml
 
-- name: Start and enable OpenSearch service
+- name: Enable OpenSearch service
   ansible.builtin.systemd:
     name: opensearch
     enabled: true
-    state: started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,3 +6,9 @@
   ansible.builtin.systemd:
     name: opensearch
     enabled: true
+
+- name: Start OpenSearch service
+  ansible.builtin.systemd:
+    name: opensearch
+    state: started
+  when: opencast_opensearch_started | bool

--- a/tasks/opensearch.yml
+++ b/tasks/opensearch.yml
@@ -1,5 +1,6 @@
 ---
 - name: OpenSearch Install on Debian
+  notify: Restart opensearch
   ansible.builtin.apt:
     name:
       - opensearch
@@ -9,6 +10,7 @@
   when: ansible_os_family == 'Debian'
 
 - name: OpenSearch Install on EL
+  notify: Restart opensearch
   ansible.builtin.dnf:
     name:
       - opensearch


### PR DESCRIPTION
It is a good idea using Ansible good practices re-/starting services only if needed. This should be done with notify.