### PR TITLE
Document version for Opencast ≤ 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Ansible: Opencast OpenSearch Role
 ![lint](https://github.com/elan-ev/opencast_opensearch/actions/workflows/lint.yml/badge.svg)
 ![molecule](https://github.com/elan-ev/opencast_opensearch/actions/workflows/molecule.yml/badge.svg)
 
+> ℹ️ Use version 0.2.0 for Opencast 16 and below.
+
 This Ansible role installs and prepares OpenSearch for Opencast.
 
 This role supports the following,


### PR DESCRIPTION
The Opencast ≤ 16 repositories do not provide the `analysis-icu` plugin. That is why users should use `0.2.0` for older versions of Opencast.

This patch adds a note about that to the documentation.