### PR TITLE
Don't define Ansible dependency roles twice

### DIFF
--- a/.dev_requirements.txt
+++ b/.dev_requirements.txt
@@ -1,5 +1,4 @@
 ansible
-ansible-core>=2.13.9
 ansible-lint
 yamllint
 molecule

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,9 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: install dependencies
-        run: >
-          pip install -r .dev_requirements.txt
+      - name: Install dependencies
+        run: pip install -r .dev_requirements.txt
 
       - run: yamllint --strict -c .yamllint .
 

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -12,13 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: install dependencies
+      - name: Install dependencies
         run: pip install -r .dev_requirements.txt
 
-      - name: install Ansbile dependencies
-        run: ansible-galaxy install -r requirements.yml
-
-      - name: test playbook
+      - name: Test playbook
         run: molecule test
         env:
           PY_COLORS: '1'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,5 +23,5 @@ galaxy_info:
         - jammy
         - noble
 dependencies:
-  - role: elan.opencast_repository
+  - name: elan.opencast_repository
     version: v0.1.0

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,6 +6,6 @@
     opencast_repository_enabled_release: true
     opencast_opensearch_heap_size: 100m
   tasks:
-    - name: Include opensearch role
+    - name: Apply opencast_opensearch role
       ansible.builtin.include_role:
-        name: "opencast_opensearch"
+        name: elan.opencast_opensearch

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -3,7 +3,7 @@ driver:
   name: containers
 dependency:
   name: galaxy
-  enabled: false
+  enabled: true
 platforms:
   # GH Action for EL8 fails
   # - name: el8

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,0 +1,3 @@
+---
+- name: elan.opencast_repository
+  version: v0.1.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,0 @@
----
-
-roles:
-  - name: elan.opencast_repository
-    version: v0.1.0


### PR DESCRIPTION
As the Ansible depencency roles are defined in meta/main.yml, we don't need defining them twice in requirements.yml.

How to test:
1. Change to an empty directory
1. Create and enable python venv
1. Install Ansible via pip
1. Make sure Ansible role `elan.opencast_repository` is not installed
1. Create `requirements.yml` with following content
```
---
roles:
  - name: elan.opencast_opensearch
    src: https://github.com/elan-ev/opencast_opensearch
    version: ansible-galaxy-should-install-dependencies
```
1. Install Ansible roles with `ansible-galaxy install -r requirements.yml  -f`

The `elan.opencast_repository` Ansible role should also be installed.