### PR TITLE
Ansible role properities should be prefixed with role name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ This role supports the following,
 - `opencast_opensearch_heap_size`
   - Memory configuration (default: `1g`)
   - Might make sense to set this to `2g` for larger installations.
-- `opensearch_api_host`
+- `opencast_opensearch_api_host`
   - Defaults to `127.0.0.1`.
-- `opensearch_api_port`
+- `opencast_opensearch_api_port`
   - Defaults to `9200`.
 - `opencast_opensearch_started`
   - By default, the OpenSearch service will (re)start if something has changed that requires the service to be restarted. This is done via the Ansible notification handler. However, if you expect the OpenSearch service to be running when you run this role, you can force the service to start by setting the value to `true`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,10 +3,10 @@
 opencast_opensearch_heap_size: 1g
 
 # Bind OpenSearch to this specific interface.
-opensearch_api_host: 127.0.0.1
+opencast_opensearch_api_host: 127.0.0.1
 
 # Bind OpenSearch to this specific port.
-opensearch_api_port: 9200
+opencast_opensearch_api_port: 9200
 
 # Whether to force the start of the OpenSearch service at the end of this role.
 opencast_opensearch_started: false

--- a/templates/opensearch.yml
+++ b/templates/opensearch.yml
@@ -1,7 +1,7 @@
 cluster.name: "opensearch-cluster"
 node.name: "{{ inventory_hostname }}"
-network.host: "{{ opensearch_api_host }}"
-http.port: "{{ opensearch_api_port }}"
+network.host: "{{ opencast_opensearch_api_host }}"
+http.port: "{{ opencast_opensearch_api_port }}"
 discovery.type: single-node
 bootstrap.memory_lock: true
 plugins.security.disabled: true


### PR DESCRIPTION
Ansible linter give you a warning about properties not prefixed with role name. This PR should address this issue.